### PR TITLE
filenameMin not working, pattern matcher ignores it

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -46,7 +46,7 @@ module.exports = util = {
 		if(opts.allowRev) {
 			url = url.replace(/-\w{8}(\..+)$/, '$1');
 		}
-		url = url.replace(/\.(min\.)?(\..+)$/, '.min.$2');
+		url = url.replace(/(min\.)?(\..+)$/, '.min$2');
 		return url;
 	},
 	


### PR DESCRIPTION
We are trying to replace something like this 

`<script src="/bower_components/angular/angular.js"></script>`

with 

`<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.17/angular.min.js"></script>`

but we keep getting

`<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.17/angular.js"></script>`
