### PR TITLE
Ensure matchers work without attribute quotes.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,7 +2,7 @@ var minimatch = require('minimatch'),
 	fs = require('fs'),
 	path = require('path'),
 	_ = require('lodash');
-	
+
 
 function getBowerRoot(opts) {
 	if(!opts._bowerRoot) {
@@ -26,13 +26,13 @@ module.exports = util = {
 	 * Matchers for various tags and CSS properties that we might replace
 	 */
 	matchers: [
-		{ pattern: /(<script\s.*?src=["'])(.+?)(["'].*?>\s*<\/script>)/gi, fallback: true },
-		{ pattern: /(<link\s.*?href=["'])(.+?)(["'].*?>\s*<\/link>)/gi, fallback: true },
-		{ pattern: /(<link\s.*?href=["'])(.+?)(["'].*?\/?>)/gi, fallback: true },
-		{ pattern: /(<img\s.*?src=["'])(.+?)(["'])/gi, fallback: false },
+		{ pattern: /(<script\s.*?src=["']?)(.+?)(["']?\s*\/?>\s*<\/script>)/gi, fallback: true },
+		{ pattern: /(<link\s.*?href=["']?)(.+?)(["']?\s*\/?>\s*<\/link>)/gi, fallback: true },
+		{ pattern: /(<link\s.*?href=["']?)(.+?)(["']?\s*\/?>)/gi, fallback: true },
+		{ pattern: /(<img\s.*?src=["']?)(.+?)(["']?\s*\/?>)/gi, fallback: false },
 		{ pattern: /(url\(['"]?)(.+?)(['"]?\))/gi, fallback: false }
 	],
-	
+
 	findFileInfo: function(url, opts) {
 		url = decodeURIComponent(url);
 		url = path.join(opts.relativeRoot, url);
@@ -40,7 +40,7 @@ module.exports = util = {
 			return minimatch(url, fileInfo.file);
 		});
 	},
-		
+
 	getFilenameMin: function(url, opts) {
 		url = path.basename(url);
 		if(opts.allowRev) {
@@ -49,7 +49,7 @@ module.exports = util = {
 		url = url.replace(/(\.min)?(\..+)$/, '.min$2');
 		return url;
 	},
-	
+
 	getVersionInfo: function(pkg, opts) {
 		if(!pkg) return {};
 		if(!opts._versionInfoCache) opts._versionInfoCache = {};

--- a/test/expected/index-without-quotes.html
+++ b/test/expected/index-without-quotes.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><title>Foo</title><script src=//examplecdn/js/all.js></script><link rel=stylesheet href=//examplecdn/css/all.css><body><img src=//examplecdn/img/fabulous.jpg>

--- a/test/fixtures/index.min.html
+++ b/test/fixtures/index.min.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><title>Foo</title><script src=js/all.js></script><link rel=stylesheet href=css/all.css><body><img src=img/fabulous.jpg>

--- a/test/main.js
+++ b/test/main.js
@@ -15,9 +15,9 @@ function processInput(opts, fixtureFileName, expectedFileName) {
 		srcFile = fs.readFileSync("test/fixtures/"+fixtureFileName, "utf8"),
 		expected = fs.readFileSync("test/expected/"+expectedFileName, "utf8"),
 		result = converter(srcFile);
-	
+
 	result.should.not.be.empty;
-	
+
 	result.should.equal(expected);
 }
 
@@ -79,10 +79,17 @@ describe("cdnizer: basic input", function() {
       matchers: [ /(<img\s.*?data-src=["'])(.+?)(["'].*?>)/gi ]
     }, 'index.html', 'index-data-src.html');
   });
+
+	it("should handle HTML without quoted attributes", function() {
+		processInput({
+			files: ['img/**/*.jpg', 'css/**/*.css', 'js/**/*.js'],
+			defaultCDNBase: '//examplecdn'
+		}, 'index.min.html', 'index-without-quotes.html')
+	});
 });
 
 describe("cdnizer: bower tests", function() {
-	
+
 	it("should handle bower versions (.bowerrc)", function() {
 		processInput({
 			files: [
@@ -110,7 +117,7 @@ describe("cdnizer: bower tests", function() {
 });
 
 describe("cdnizer: css files", function() {
-	
+
 	it("should handle css files (no modification)", function() {
 		processInput(['/no/match'], 'style.css', 'style-none.css');
 	});
@@ -126,7 +133,7 @@ describe("cdnizer: css files", function() {
 
 
 describe("cdnizer: error handling", function() {
-	
+
 	it("should error on no input", function() {
 		(function(){
 			cdnizer();
@@ -141,7 +148,7 @@ describe("cdnizer: error handling", function() {
 			cdnizer({files:[]});
 		}).should.throw();
 	});
-	
+
 	it("should error on invalid input", function() {
 		(function(){
 			cdnizer(9);
@@ -159,7 +166,7 @@ describe("cdnizer: error handling", function() {
 			cdnizer({files:{}});
 		}).should.throw();
 	});
-	
+
 	it("should error on invalid files", function() {
 		(function(){
 			cdnizer({files:[{file:9}]});
@@ -171,5 +178,5 @@ describe("cdnizer: error handling", function() {
 			cdnizer({files:['/not/invalid', {file:new Date()}]});
 		}).should.throw();
 	});
-	
+
 });


### PR DESCRIPTION
The matchers currently completely ignore minified HTML where quotes are
stripped from the attributes. This PR adjusts the matchers to make
quotes optional and also adds some test cases to make sure everything
works.
