### PR TITLE
Fix matching for more complex inline javascripts

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -27,7 +27,7 @@ module.exports = util = {
 	 */
 	matchers: [
 		// script with quoted src
-		{ pattern: /(<script\s[\s\S]*?src=["'])([\s\S]+?)(["'][^>]*>\s*<\/script>)/gi, fallback: true },
+		{ pattern: /(<script\s[\s\S]*?src=["'])([\s\S]+?)(["'][^>]*>*<\/script>)/gi, fallback: true },
 		// script with unquoted src
 		{ pattern: /(<script\s[\s\S]*?src=)([\s\S]+?)((?:>|\s[^>]*>)\s*<\/script>)/gi, fallback: true },
 

--- a/test/expected/index-inline-js.html
+++ b/test/expected/index-inline-js.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<script type="text/javascript">
+	window.intercomAppId = 'XXX';
+	(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;
+
+		s.src='https://widget.intercom.io/widget/'+window.intercomAppId;
+
+		var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+	</script>
+</head>
+<body>
+	<script src="//cdnhost/libs/min/jquery.js"></script>
+	<script src="//cdnhost/libs/min/underscore.js"></script>
+</body>
+</html>

--- a/test/fixtures/index-inline-js.html
+++ b/test/fixtures/index-inline-js.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<script type="text/javascript">
+	window.intercomAppId = 'XXX';
+	(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;
+
+		s.src='https://widget.intercom.io/widget/'+window.intercomAppId;
+
+		var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+	</script>
+</head>
+<body>
+	<script src="libs/jquery.js"></script>
+	<script src="libs/underscore.js"></script>
+</body>
+</html>

--- a/test/main.js
+++ b/test/main.js
@@ -122,12 +122,29 @@ describe("cdnizer: basic input", function() {
 		}, 'index-underscore-template.html', 'index-underscore-template.html');
 	});
 
+
 	it("should be unaffected by inline javascript", function() {
 		processInput({
 			files: ['css/main.css', 'js/**/*.js'],
 			defaultCDNBase: '//examplecdn/'
 		}, 'inline-javascript.html', 'inline-javascript.html');
 	});
+
+	it("should handle inline javascript", function() {
+                debugger;
+                var cdnBase = '//cdnhost/libs/min';
+                processInput({
+                        files: [
+                                {
+                  file: 'libs/jquery.js',
+                  cdn: cdnBase + '/jquery.js'
+                },
+                {
+                  file: 'libs/underscore.js',
+                  cdn: cdnBase + '/underscore.js'
+                }]
+                }, 'index-inline-js.html', 'index-inline-js.html');
+        });
 });
 
 describe("cdnizer: bower tests", function() {


### PR DESCRIPTION
The regex was a little bit to hungry and did not match the closing </script> tag if the inlined javascript contained code with `src='something'`. Added a test and fixed the regex. Please consider for release together with gulp-cdnizer.