### PR TITLE
Updated minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "google-cdn-data": "^0.1.6",
     "jsdelivr-cdn-data": "^0.1.1",
     "lodash": "~2.4.1",
-    "minimatch": "^1.0.0",
+    "minimatch": "^3.0.2",
     "nomnom": "^1.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hola!

seems like minimatch pre-3.0.2 has a [sec vulnerability](https://nodesecurity.io/advisories/118). Just upgraded it and tests seem to run fine.
