### PR TITLE
Update version of jsdelivr-cdn-data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -571,17 +571,16 @@
       "dev": true
     },
     "jsdelivr-cdn-data": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsdelivr-cdn-data/-/jsdelivr-cdn-data-0.1.1.tgz",
-      "integrity": "sha1-pFDi3G7O57t7b2pylOUYCsvJwQo=",
+      "version": "git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0",
+      "from": "git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0",
       "requires": {
-        "semver": "~2.2.1"
+        "semver": "^5.3.0"
       },
       "dependencies": {
         "semver": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
-          "integrity": "sha1-eUEYKz/8xYC/8cF5QqzfeVHA0hM="
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "cdnjs-cdn-data": "^0.1.1",
     "google-cdn-data": "^0.1.6",
-    "jsdelivr-cdn-data": "^0.1.1",
+    "jsdelivr-cdn-data": "git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0",
     "lodash": "^4.17.11",
     "minimatch": "^3.0.2"
   },


### PR DESCRIPTION
I had to pin the version of `jsdelivr-cdn-data` to a git hash because it wasn't published to npm or git tagged (and doesn't look like it will be anytime soon). 

The commit they have that updated semver is located here: https://github.com/shahata/jsdelivr-cdn-data/commits/master

It's been in master a while and still no publish to NPM, so I assume they don't plan to.

This resolves the `npm audit`/`nsp` issues people are having.

cc: @OverZealous 