### PR TITLE
add exclusions for absolute URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ var cdnizer = cdnizerFactory([
 	* [bowerComponents](#optionsbowercomponents)
 	* [matchers](#optionsmatchers)
 	* [cdnDataLibraries](#optionscdndatalibraries)
+	* [excludeAbsolute](#optionsexcludeabsolute)
 * [Files Array](#optionsfiles)
 	* [Type: glob](#optionsfilesglob)
 	* [Type: common public cdn](#optionsfilescommon-cdn)
@@ -360,6 +361,55 @@ Default: `[]`
 
 Future-proof option to add additional `*-cdn-data` packages.  These packages *must* be in the same format as [`google-cdn-data`](https://www.npmjs.org/package/google-cdn-data).  The format is to only include the leading part of the package name, for example, `cdnjs-cdn-data` would be included as simply `'cdnjs'`.
 
+#### options.excludeAbsolute
+
+Type: `Boolean`
+Default: `false`
+
+In [some cases](https://github.com/OverZealous/cdnizer/issues/21) you may have third party of vendor libraries already loaded off a CDN or remote URL that you don't want re-written.  
+
+For example given a config like this
+```js
+var cdnizerFactory = require("cdnizer");
+var cdnizer = cdnizerFactory(
+	files: ['**/*.js', '**/*.css'],
+	defaultCDNBase: '//examplecdn/',
+	excludeAbsolute: true
+]);
+```
+
+And an _index.html_ like this
+```html
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title></title>
+		<link href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
+	</head>
+	<body>
+	<h1>Hello World</h1>
+	<script src="js/app/app.js"></script>
+	</body>
+</html>
+```
+
+With this flag enabled `cdnizer` will avoid re-writing these kind of paths.
+```html
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title></title>
+		<!-- path has not changed -->
+		<link href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
+	</head>
+	<body>
+	<h1>Hello World</h1>
+		<script src="//examplecdn/js/app/app.js"></script> <!-- has the expected CDN base path -->
+	</body>
+</html>
+```
 
 ### options.files
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,12 @@ function makeCdnizer(opts) {
 						package: fileInfo.package,
 						test: fileInfo.test
 					});
-					result += _.template(fileInfo.cdn || opts.defaultCDN, lodashTemplateSettings)(params);
+					var excludeCdnPrefix = /^([a-z]+:)?\/\//i.test(url);
+					var cdnTemplate = opts.excludeAbsolute && excludeCdnPrefix
+						? '<%= filepath %>'
+						: fileInfo.cdn || opts.defaultCDN;
+
+					result += _.template(cdnTemplate, lodashTemplateSettings)(params);
 					result += post;
 					if(canAddFallback && m.fallback && fileInfo.test) {
 						result += _.template(opts.fallbackTest, lodashTemplateSettings)(params);

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -12,6 +12,7 @@ var defaults = {
 	fallbackScript: '<scr' + 'ipt>function cdnizerLoad(u) {document.write(\'<scr\'+\'ipt src="\'+encodeURIComponent(u)+\'"></scr\'+\'ipt>\');}</script>',
 	fallbackTest: '<scr' + 'ipt>if(!(${ test })) cdnizerLoad("${ filepath }");</script>',
 	shouldAddFallback: false,
+	excludeAbsolute: false,
 	matchers: []
 };
 

--- a/test/expected/index-exclusions.html
+++ b/test/expected/index-exclusions.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title></title>
+	<link href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
+	<link rel="stylesheet" href="//examplecdn/css/main.css">
+</head>
+<body>
+<h1>Hello World</h1>
+<script src="//examplecdn/js/vendor/angular/angular.min.js"></script>
+<script src="//examplecdn/js/vendor/firebase/firebase.js"></script>
+<script src="//examplecdn/js/vendor/angularfire/angularfire.js"></script>
+<script src="//examplecdn/js/app/app.js"></script>
+<img data-src="img/pretty.jpg" />
+</body>
+</html>

--- a/test/fixtures/index-exclusions.html
+++ b/test/fixtures/index-exclusions.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title></title>
+	<link href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
+	<link rel="stylesheet" href="css/main.css">
+</head>
+<body>
+<h1>Hello World</h1>
+<script src="js/vendor/angular/angular.min.js"></script>
+<script src="js/vendor/firebase/firebase.js"></script>
+<script src="js/vendor/angularfire/angularfire.js"></script>
+<script src="js/app/app.js"></script>
+<img data-src="img/pretty.jpg" />
+</body>
+</html>

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -133,5 +133,13 @@ module.exports = function(cdnizer, processInput) {
 					}]
 			}, 'index-inline-js.html', 'index-inline-js.html');
 		});
+
+		it("should handle excludeAbsolute config flag to ignore absolute URLs", function() {
+			processInput({
+				files: ['**/*.js', '**/*.png', '**/*.css'],
+				defaultCDNBase: '//examplecdn/',
+				excludeAbsolute: true,
+			}, 'index-exclusions.html', 'index-exclusions.html');
+		});
 	});
 };


### PR DESCRIPTION
resolves #21 by adding exceptions for paths that wouldn't need cdnizing, like:
- `//cdn.com/lib/index.js`
- `http[s]://cdn.com/lib/index.js`