### PR TITLE
Replace incorrect jsdelivr-cdn-data git url with semver in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -571,16 +571,17 @@
       "dev": true
     },
     "jsdelivr-cdn-data": {
-      "version": "git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0",
-      "from": "git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/jsdelivr-cdn-data/-/jsdelivr-cdn-data-1.0.4.tgz",
+      "integrity": "sha512-0C/7mF2lfPCi9Eg5MtGXc0jJ24iHQdg+k9PGPtKPISsEbYX2kFNuw59ynHjmNw6M9AmPN9GZkYVuWRnbcjFhRw==",
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "^5.7.1"
       },
       "dependencies": {
         "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "cdnjs-cdn-data": "^0.1.1",
     "google-cdn-data": "^0.1.6",
-    "jsdelivr-cdn-data": "git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0",
+    "jsdelivr-cdn-data": "^1.0.4",
     "lodash": "^4.17.11",
     "minimatch": "^3.0.2"
   },


### PR DESCRIPTION
We cannot install dependencies such as webpack-s3-plugin due to an incorrect git url specified in the package.json. (See #36)

This fixes the problem by updating the git url of jsdelivr-cdn-data.

<img width="993" alt="image" src="https://user-images.githubusercontent.com/3102175/66905975-d050af80-f041-11e9-8f58-55d9753dcc1f.png">
