### PR TITLE
Bump Lodash to v4.17.12 to include security patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cdnjs-cdn-data": "^0.1.1",
     "google-cdn-data": "^0.1.6",
     "jsdelivr-cdn-data": "^1.0.4",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.12",
     "minimatch": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
[CVE-2019-10744](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10744) is a critical vulnerability in Lodash, specifically around prototype pollution. 

This pull request upgrades Lodash to the latest stable version, `4.17.12`.

Tests are passing: 
```shell
workspace/cdnizer|upgrade_lodash_to_4.17.12⚡
⇒  yarn test
yarn run v1.21.1
$ istanbul test _mocha --report html -- test/*.js --reporter spec


  cdnizer: basic input
    ✓ should not modify a file if no matches
    ✓ should modify on basic input
    ✓ should handle varied input
    ✓ should handle existing min and fallbacks
    ✓ should add min with filenameMin
    ✓ should handle revisioning
    ✓ should use custom matchers with an object
    ✓ should use custom matchers with just a regular expression
    ✓ should handle HTML without quoted attributes
    ✓ should correctly handle other attributes within tags
    ✓ should handle line-wrapped elements
    ✓ should handle relative paths
    ✓ should handle underscore templates
    ✓ should be unaffected by inline javascript
    ✓ should handle inline javascript
    ✓ should handle excludeAbsolute config flag to ignore absolute URLs

  cdnizer: node modules tests
    ✓ should work with default node_modules
    ✓ should work with custom node_modules
    ✓ should work for issue 29

  cdnizer: bower tests
    ✓ should handle bower versions (.bowerrc)
    ✓ should handle bower versions (passed in)
    ✓ should revert to dot-bower-packages
    ✓ should throw on no bower version

  cdnizer: css files
    ✓ should handle css files (no modification)
    ✓ should handle css files and relative roots

  cdnizer: cdn-data
    ✓ should handle known google-cdn-data
    ✓ should handle known cdnjs-cdn-data (669ms)
    ✓ should handle known jsdelivr-cdn-data (42ms)
    ✓ should handle cdns with custom filenames
    ✓ should handle cdn data with alternate files
    ✓ should handle cdn data with alternate files, automated
    ✓ should ignore protocols (colons) in custom cdns

  cdnizer: error handling
    ✓ should error on no input
    ✓ should error on invalid input
    ✓ should error on invalid files


  35 passing (835ms)

✨  Done in 1.33s.
```